### PR TITLE
Notification position switched from absolute to fixed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *.iml
+.DS_Store

--- a/notifier.js
+++ b/notifier.js
@@ -22,7 +22,7 @@
   };
 
   $(document).ready(function() {
-    config.container.css("position", "absolute");
+    config.container.css("position", "fixed");
     config.container.css("z-index", 9999);
     config.container.css(config.position[0], "12px");
     config.container.css(config.position[1], "12px");


### PR DESCRIPTION
This way when on a long page where the user has scrolled down to a position where the absolute top right corner (by default) is no longer visible - the notification will still be visible.

Also added .DS_Store to .gitignore for Mac-based developers.
